### PR TITLE
feat(c): print JSON response from Move.processEnemyFire

### DIFF
--- a/src/main/java/battleship/Game.java
+++ b/src/main/java/battleship/Game.java
@@ -345,7 +345,8 @@ public class Game implements IGame
 
 //		System.out.println(move);
 
-		move.processEnemyFire(true);
+		String responseJson = move.processEnemyFire(true);
+		System.out.println(responseJson);
 
 		alienMoves.add(move);
 

--- a/src/test/java/battleship/GameTest.java
+++ b/src/test/java/battleship/GameTest.java
@@ -1,5 +1,8 @@
 package battleship;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.junit.jupiter.api.*;
@@ -84,6 +87,24 @@ public class GameTest {
 		List<IPosition> positions = List.of(new Position(2, 3), new Position(2, 4), new Position(2, 5));
 		game.fireShots(positions);
 		assertEquals(1, game.getAlienMoves().size(), "Shots list should contain one shot after firing once.");
+	}
+
+	@Test
+	void fireShotsPrintsJsonResponseToConsole() {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		PrintStream originalOut = System.out;
+		try {
+			System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+			game.fireShots(List.of(new Position(2, 3), new Position(2, 4), new Position(2, 5)));
+		} finally {
+			System.setOut(originalOut);
+		}
+
+		String consoleOutput = output.toString(StandardCharsets.UTF_8);
+		assertTrue(consoleOutput.contains("Jogada nº1 -> 3 tiros válidos: 3 tiros na água"));
+		assertTrue(consoleOutput.contains("\"validShots\" : 3"));
+		assertTrue(consoleOutput.contains("\"missedShots\" : 3"));
+		assertTrue(consoleOutput.contains("\"outsideShots\" : 0"));
 	}
 
 	@Test


### PR DESCRIPTION
Implements item C.5 of the assignment.

What changed:
- The game now prints the JSON response returned by Move.processEnemyFire(...) to the console after each processed rajada.
- The previous human-readable summary remains unchanged.
- Added an automated test to verify that the JSON response is printed to stdout.

Validation:
- mvn -Dtest=GameTest test
- mvn test
- Manual check with gerafrota + rajada A1 B2 C3 confirms textual summary + JSON output.

Closes #8 