### PR TITLE
docs(ficha2): add YouTube demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ⚓ Battleship 2.0
 
+> Ficha 2 demo video: [Watch on YouTube](https://youtu.be/S00AQphHRkE)
+
 ![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
 ![Java Version](https://img.shields.io/badge/Java-21%2B-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)


### PR DESCRIPTION
Esta atualização ao **README** foi separada para manter o PR principal focado apenas no trabalho técnico da ficha 3.

O link para a demonstração já devia ter sido acrescentado anteriormente, mas acabou por ser incluído mais tarde do que o previsto. Para evitar misturar uma correção documental tardia com as restantes alterações do projeto, optámos por submeter este ajuste num PR autónomo.

Assim, o histórico fica mais claro e a revisão de cada alteração torna-se mais simples.