### PR TITLE
docs(qodana): add Eduardo PDF smell gate

### DIFF
--- a/.github/workflows/qodana-eduardo.yml
+++ b/.github/workflows/qodana-eduardo.yml
@@ -1,0 +1,39 @@
+# 110894 - Eduardo Sousa
+name: Qodana Eduardo PDF smell gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Qodana Scan
+        uses: JetBrains/qodana-action@v2025.3
+        with:
+          args: --config,qodana-eduardo.yaml,--fail-threshold,0
+          pr-mode: false
+          upload-result: true
+          use-annotations: true
+          post-pr-comment: true
+
+      - name: Upload SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/docs/eduardo-qodana-smell.md
+++ b/docs/eduardo-qodana-smell.md
@@ -1,0 +1,45 @@
+# Parte 2A - Qodana
+
+## Smell escolhido
+
+- Smell: `UnusedDeclaration`
+- Metodo alvo: `PdfExporter.export(GameSummary)`
+- Ficheiro: `src/main/java/battleship/PdfExporter.java`
+
+## Justificacao
+
+O requisito do PDF introduziu a classe `PdfExporter` e uma sobrecarga de metodo para exportacao:
+
+- `export(GameSummary)`
+- `export(GameSummary, Path)`
+
+A analise local com `Inspect Code` sinalizou que `export(GameSummary)` nao esta a ser usado no estado atual do projeto, enquanto o fluxo real do jogo usa a versao com `Path`.
+
+Isto torna o metodo um bom candidato a `UnusedDeclaration`, um smell de codigo morto ou API redundante.
+
+## Configuracao adicionada
+
+- `qodana-eduardo.yaml`
+- `.github/workflows/qodana-eduardo.yml`
+
+## O que a configuracao faz
+
+1. Usa `qodana-jvm-community`, para nao depender de licenca paga nem de `QODANA_TOKEN`.
+2. Usa o perfil `empty`.
+3. Inclui apenas a inspecao `UnusedDeclaration`.
+4. Limita essa inspecao ao ficheiro `src/main/java/battleship/PdfExporter.java`.
+5. Define um quality gate no workflow com `fail-threshold: 0`.
+
+Na pratica, o workflow deve falhar sempre que o Qodana reportar pelo menos um finding dessa inspecao no ficheiro alvo.
+
+## Relacao com a analise da ficha 3
+
+Este smell esta alinhado com:
+
+- a analise local feita sobre o requisito PDF
+- o issue aberto para o overload nao usado
+- o objetivo da ficha de cada membro escolher um cheiro diferente e construir um workflow Qodana para o detetar
+
+## Conclusao
+
+Foi configurado um workflow de GitHub Actions com Qodana especificamente para avaliar o smell `UnusedDeclaration` no ficheiro `src/main/java/battleship/PdfExporter.java`, com foco no metodo `PdfExporter.export(GameSummary)`.

--- a/qodana-eduardo.yaml
+++ b/qodana-eduardo.yaml
@@ -1,0 +1,12 @@
+# 110894 - Eduardo Sousa
+version: "1.0"
+linter: qodana-jvm-community
+projectJDK: 21
+
+profile:
+  name: empty
+
+include:
+  - name: UnusedDeclaration
+    paths:
+      - src/main/java/battleship/PdfExporter.java


### PR DESCRIPTION
Adds Eduardo's lab 3 Qodana smell gate for the PDF export feature.

Included:
- .github/workflows/qodana-eduardo.yml
- qodana-eduardo.yaml
- docs/eduardo-qodana-smell.md

Scope:
- smell selected: UnusedDeclaration
- target file: src/main/java/battleship/PdfExporter.java
- target method: PdfExporter.export(GameSummary)
- dedicated Qodana workflow and config using qodana-jvm-community

Related to #14