### PR TITLE
chore(ficha3): add Vasco CallToPrintStackTrace gate

### DIFF
--- a/.github/workflows/qodana-vasco.yml
+++ b/.github/workflows/qodana-vasco.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Qodana Scan (CallToPrintStackTrace)
         uses: JetBrains/qodana-action@v2025.3
         with:
-          args: --config,qodana-vasco.yaml --fail-threshold 0
+          args: --config,qodana-vasco.yaml,--fail-threshold,0
           pr-mode: false
           upload-result: true
           use-annotations: true

--- a/.github/workflows/qodana-vasco.yml
+++ b/.github/workflows/qodana-vasco.yml
@@ -1,0 +1,39 @@
+# Aluno: 111331 Vasco Rodrigues
+name: Qodana Vasco H2 smell gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Qodana Scan (CallToPrintStackTrace)
+        uses: JetBrains/qodana-action@v2025.3
+        with:
+          args: --config,qodana-vasco.yaml --fail-threshold 0
+          pr-mode: false
+          upload-result: true
+          use-annotations: true
+          post-pr-comment: true
+
+      - name: Upload SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/qodana-vasco.yml
+++ b/.github/workflows/qodana-vasco.yml
@@ -1,4 +1,4 @@
-# Aluno: 111331 Vasco Rodrigues
+# Aluno: 111331 Vasco Reis Teixeira
 name: Qodana Vasco H2 smell gate
 
 on:
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   qodana:

--- a/docs/vasco-qodana-smell.md
+++ b/docs/vasco-qodana-smell.md
@@ -1,20 +1,19 @@
-# 111331 - Vasco Rodrigues
+# 111331 - Vasco Reis Teixeira
 
 ## Smell escolhido
-
 - **CallToPrintStackTrace**
 - **Ficheiro alvo:** `src/main/java/battleship/GameHistory.java`
-- **Contexto do requisito:** H2 / histórico de jogos (ficha 2)
+- **Contexto do requisito:** H2 / historico de jogos (ficha 2)
 
-## Justificação
-
-`GameHistory` contém chamadas diretas a `e.printStackTrace()` nos blocos `catch (SQLException e)`.
-Este padrão é um smell porque não há tratamento estruturado do erro e o output fica acoplado a `stderr`, dificultando controlo operacional e testes.
+## Justificacao
+`GameHistory` contem chamadas diretas a `e.printStackTrace()` nos blocos `catch (SQLException e)`.
+Este padrao e um smell porque nao ha tratamento estruturado do erro e o output fica
+acoplado a `stderr`, dificultando controlo operacional e testes.
 
 ## Quality gate configurado
-
 - Workflow: `.github/workflows/qodana-vasco.yml`
 - Config: `qodana-vasco.yaml`
-- Inspeção ativa: `CallToPrintStackTrace`
+- Linter: `qodana-jvm-community`
+- Inspecao ativa: `CallToPrintStackTrace`
 - Escopo limitado ao ficheiro `GameHistory.java`
 - Gate: `--fail-threshold 0`

--- a/docs/vasco-qodana-smell.md
+++ b/docs/vasco-qodana-smell.md
@@ -1,0 +1,20 @@
+# 111331 - Vasco Rodrigues
+
+## Smell escolhido
+
+- **CallToPrintStackTrace**
+- **Ficheiro alvo:** `src/main/java/battleship/GameHistory.java`
+- **Contexto do requisito:** H2 / histórico de jogos (ficha 2)
+
+## Justificação
+
+`GameHistory` contém chamadas diretas a `e.printStackTrace()` nos blocos `catch (SQLException e)`.
+Este padrão é um smell porque não há tratamento estruturado do erro e o output fica acoplado a `stderr`, dificultando controlo operacional e testes.
+
+## Quality gate configurado
+
+- Workflow: `.github/workflows/qodana-vasco.yml`
+- Config: `qodana-vasco.yaml`
+- Inspeção ativa: `CallToPrintStackTrace`
+- Escopo limitado ao ficheiro `GameHistory.java`
+- Gate: `--fail-threshold 0`

--- a/docs/vasco-qodana-smell.md
+++ b/docs/vasco-qodana-smell.md
@@ -17,3 +17,10 @@ acoplado a `stderr`, dificultando controlo operacional e testes.
 - Inspecao ativa: `CallToPrintStackTrace`
 - Escopo limitado ao ficheiro `GameHistory.java`
 - Gate: `--fail-threshold 0`
+
+## Nota de validacao
+O ficheiro alvo contem chamadas a `printStackTrace()` em blocos `catch`, pelo que a configuracao deve
+ser validada diretamente pelo run do GitHub Actions e pelo respetivo comentario do Qodana na PR.
+
+Se o run nao reportar findings, deve confirmar-se primeiro se a inspecao esta realmente a ser aplicada
+com a configuracao pretendida antes de fechar a analise como concluida.

--- a/qodana-vasco.yaml
+++ b/qodana-vasco.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+linter: qodana-jvm-community
+projectJDK: 21
+
+profile:
+  name: empty
+
+include:
+  - name: CallToPrintStackTrace
+    paths:
+      - src/main/java/battleship/GameHistory.java


### PR DESCRIPTION
## Objetivo
Configurar a parte do Vasco (111331) para detecao do smell `CallToPrintStackTrace` no requisito H2/historico.

## Inclui
- `.github/workflows/qodana-vasco.yml`
- `qodana-vasco.yaml`
- `docs/vasco-qodana-smell.md`

## Configuracao
- Linter: `qodana-jvm-community`
- Inspecao: `CallToPrintStackTrace`
- Escopo: `src/main/java/battleship/GameHistory.java`
- Gate: `--fail-threshold 0`

## Nota
Nao altera `qodana.yaml` nem `.github/workflows/qodana.yml` para evitar conflito com a PR #16.
