### PR TITLE
ci(ficha3): add SonarQube Cloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,47 @@
+name: SonarQube Cloud
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  sonarcloud:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Build and analyze with SonarQube Cloud
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          mvn -B verify
+          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.organization=rtz15
+          -Dsonar.projectKey=rtz15_Battleship2

--- a/SonarQube/README.md
+++ b/SonarQube/README.md
@@ -8,7 +8,18 @@ identificacao pelo respetivo numero de aluno, conforme pedido no enunciado.
 Conteudos esperados por membro:
 - screenshot ou relatorio PDF do SonarQube
 
-Convencao de nomes sugerida:
+Ficheiros esperados na `main`:
 - `110894-eduardo-sonarqube.png`
 - `111331-vasco-sonarqube.png`
 - `123026-tiago-sonarqube.png`
+
+Preparacao do repositorio:
+- workflow em `.github/workflows/sonarcloud.yml`
+- secret GitHub obrigatorio: `SONAR_TOKEN`
+- sem uso de `SONAR_HOST_URL`
+
+Validacao final pedida no enunciado:
+- criar um erro temporario e controlado numa branch de teste ou PR
+- confirmar a execucao do workflow SonarQube Cloud no GitHub Actions
+- recolher o print ou relatorio individual no SonarQube Cloud
+- remover o erro de teste depois da validacao


### PR DESCRIPTION
Resumo:
Esta PR fecha a parte SonarQube Cloud + GitHub Actions da tarefa 2.B da ficha 3.

Alterações:
- adiciona `.github/workflows/sonarcloud.yml`
- configura análise SonarQube Cloud para Maven/Java 21
- usa `SONAR_TOKEN` via GitHub Secrets
- não usa `SONAR_HOST_URL`
- atualiza `SonarQube/README.md` com os nomes dos screenshots esperados

Validação local:
- `mvn -B verify` executado com sucesso

Já configurado fora do repositório:
- projeto `Battleship2` ligado ao SonarQube Cloud
- secret `SONAR_TOKEN` criado no GitHub

Fica a faltar:
- correr o workflow
- guardar os 3 screenshots em `SonarQube/`
- validar com erro controlado

Closes #26