### PR TITLE
Refactoring 123026

### DIFF
--- a/RefactoringOpportunities.md
+++ b/RefactoringOpportunities.md
@@ -20,8 +20,8 @@ This file records the refactoring candidates identified after the Ficha 4 testin
 | R4 | Vasco | `Tasks` | Break `menu()` into command handlers | The command loop concentrates many responsibilities and is the most complex CLI method in the project | - | Pending |
 | R5 | Eduardo | `Game` | Extract summary-building helpers from `createSummary()` and `buildMoveSummary()` | Summary generation is correct but dense, which makes future changes harder to isolate | - | Done on `Refactoring_110894` |
 | R6 | Eduardo | `PdfExporter` | Consolidate repetitive PDF line-writing steps into small section helpers | The exporter is stable but still writes every section procedurally in a single method | - | Done on `Refactoring_110894` |
-| R7 | Tiago | `Messages` / `AppLanguage` | Extract and centralize default-language resolution paths | Language fallback logic is simple but duplicated conceptually across localization entry points | - | Pending |
-| R8 | Tiago | `LanguageSupport` / `Main` | Isolate CLI language parsing from application startup | Entry-point concerns and language resolution can be made more explicit and easier to test | - | Pending |
+| R7 | Tiago | `Messages` / `AppLanguage` | Extract and centralize default-language resolution paths | Language fallback logic is simple but duplicated conceptually across localization entry points | `#36` | Done on `Refactoring_123026` |
+| R8 | Tiago | `LanguageSupport` / `Main` | Isolate CLI language parsing from application startup | Entry-point concerns and language resolution can be made more explicit and easier to test | `#37` | Done on `Refactoring_123026` |
 | R9 | Vasco | `Tasks` | Extract history-printing and fleet-loading helpers from the CLI loop | `menu()` still mixes input orchestration with printing and persistence concerns | - | Pending |
 | R10 | Eduardo | `Move` | Split verbose text construction from JSON response construction | `processEnemyFire()` currently handles counting, message construction and serialization in one method | - | Done on `Refactoring_110894` |
 

--- a/src/main/java/battleship/AppLanguage.java
+++ b/src/main/java/battleship/AppLanguage.java
@@ -8,6 +8,8 @@ enum AppLanguage {
 	PORTUGUESE("pt", ULocale.forLanguageTag("pt-PT")),
 	ENGLISH("en", ULocale.ENGLISH);
 
+	private static final AppLanguage DEFAULT_LANGUAGE = PORTUGUESE;
+
 	private final String code;
 	private final ULocale locale;
 
@@ -25,14 +27,25 @@ enum AppLanguage {
 	}
 
 	public static AppLanguage fromCode(String code) {
-		if (code == null || code.isBlank())
-			return PORTUGUESE;
+		String normalizedCode = normalize(code);
+		if (normalizedCode == null)
+			return DEFAULT_LANGUAGE;
 
-		String normalized = code.trim().toLowerCase(Locale.ROOT);
-		if (normalized.startsWith(ENGLISH.code))
-			return ENGLISH;
-		if (normalized.startsWith(PORTUGUESE.code))
-			return PORTUGUESE;
-		return PORTUGUESE;
+		for (AppLanguage language : values()) {
+			if (language.matches(normalizedCode))
+				return language;
+		}
+
+		return DEFAULT_LANGUAGE;
+	}
+
+	private static String normalize(String code) {
+		if (code == null || code.isBlank())
+			return null;
+		return code.trim().toLowerCase(Locale.ROOT);
+	}
+
+	private boolean matches(String normalizedCode) {
+		return normalizedCode.startsWith(code);
 	}
 }

--- a/src/main/java/battleship/LanguageSupport.java
+++ b/src/main/java/battleship/LanguageSupport.java
@@ -2,6 +2,7 @@ package battleship;
 
 final class LanguageSupport {
 	private static final String LANGUAGE_FLAG = "--lang";
+	private static final String INLINE_LANGUAGE_FLAG = LANGUAGE_FLAG + "=";
 	private static final String LANGUAGE_ENV = "BATTLESHIP_LANG";
 
 	private LanguageSupport() {
@@ -12,8 +13,12 @@ final class LanguageSupport {
 	}
 
 	static AppLanguage resolve(String[] args, String envLanguage) {
+		return AppLanguage.fromCode(resolveLanguageCode(args, envLanguage));
+	}
+
+	private static String resolveLanguageCode(String[] args, String envLanguage) {
 		String cliLanguage = extractCliLanguage(args);
-		return AppLanguage.fromCode(cliLanguage != null ? cliLanguage : envLanguage);
+		return cliLanguage != null ? cliLanguage : envLanguage;
 	}
 
 	private static String extractCliLanguage(String[] args) {
@@ -22,12 +27,27 @@ final class LanguageSupport {
 
 		for (int i = 0; i < args.length; i++) {
 			String arg = args[i];
-			if (LANGUAGE_FLAG.equals(arg) && i + 1 < args.length)
-				return args[i + 1];
-			if (arg.startsWith(LANGUAGE_FLAG + "="))
-				return arg.substring((LANGUAGE_FLAG + "=").length());
+			String separatedValue = extractSeparatedFlagValue(args, i);
+			if (separatedValue != null)
+				return separatedValue;
+
+			String inlineValue = extractInlineFlagValue(arg);
+			if (inlineValue != null)
+				return inlineValue;
 		}
 
+		return null;
+	}
+
+	private static String extractSeparatedFlagValue(String[] args, int index) {
+		if (LANGUAGE_FLAG.equals(args[index]) && index + 1 < args.length)
+			return args[index + 1];
+		return null;
+	}
+
+	private static String extractInlineFlagValue(String arg) {
+		if (arg.startsWith(INLINE_LANGUAGE_FLAG))
+			return arg.substring(INLINE_LANGUAGE_FLAG.length());
 		return null;
 	}
 }

--- a/src/main/java/battleship/Messages.java
+++ b/src/main/java/battleship/Messages.java
@@ -6,15 +6,16 @@ import com.ibm.icu.text.MessageFormat;
 
 final class Messages {
 	private static final String BUNDLE_NAME = "battleship.messages";
+	private static final AppLanguage DEFAULT_LANGUAGE = AppLanguage.PORTUGUESE;
 
-	private static AppLanguage currentLanguage = AppLanguage.PORTUGUESE;
+	private static AppLanguage currentLanguage = DEFAULT_LANGUAGE;
 	private static ResourceBundle bundle = loadBundle(currentLanguage);
 
 	private Messages() {
 	}
 
 	public static void configure(AppLanguage language) {
-		currentLanguage = language == null ? AppLanguage.PORTUGUESE : language;
+		currentLanguage = resolveLanguage(language);
 		bundle = loadBundle(currentLanguage);
 	}
 
@@ -23,11 +24,18 @@ final class Messages {
 	}
 
 	public static String format(String key, Object... args) {
-		MessageFormat formatter = new MessageFormat(get(key), currentLanguage.toULocale());
-		return formatter.format(args);
+		return createFormatter(key).format(args);
+	}
+
+	private static AppLanguage resolveLanguage(AppLanguage language) {
+		return language == null ? DEFAULT_LANGUAGE : language;
 	}
 
 	private static ResourceBundle loadBundle(AppLanguage language) {
 		return ResourceBundle.getBundle(BUNDLE_NAME, language.toLocale());
+	}
+
+	private static MessageFormat createFormatter(String key) {
+		return new MessageFormat(get(key), currentLanguage.toULocale());
 	}
 }


### PR DESCRIPTION
## Summary
- Extracts language-code normalization and matching from `AppLanguage.fromCode(String)`.
- Makes Portuguese fallback/default language resolution explicit in `AppLanguage` and `Messages`.
- Splits CLI language parsing in `LanguageSupport` into separated `--lang en` and inline `--lang=en` helpers.
- Marks Tiago's R7/R8 backlog entries as complete with their linked issues.

## Validation
- `mvn test`: 216 tests, 0 failures, 0 errors.
- `mvn clean verify javadoc:javadoc`: build success; existing Javadoc/shade warnings only.

Closes #36
Closes #37