### PR TITLE
Refactoring 111331

### DIFF
--- a/RefactoringOpportunities.md
+++ b/RefactoringOpportunities.md
@@ -14,15 +14,15 @@ This file records the refactoring candidates identified after the Ficha 4 testin
 
 | ID | Owner | Area | Candidate | Motivation | Related issue | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| R1 | Vasco | `GameHistory` | Replace duplicated `printStackTrace()` handling with a shared error-reporting strategy | Error handling is repeated in the constructor, `saveGame()` and `getHistory()` | `#23` | Pending |
+| R1 | Vasco | `GameHistory` | Replace duplicated `printStackTrace()` handling with a shared error-reporting strategy | Error handling is repeated in the constructor, `saveGame()` and `getHistory()` | `#23` | Done on `Refactoring_111331` |
 | R2 | Eduardo | `Game` | Simplify `randomEnemyFire()` by extracting candidate filtering and shot selection | The method mixes filtering, random selection, console output and fallback padding in one block | `#21` | Done on `Refactoring_110894` |
 | R3 | Eduardo | `Game` / `Move` | Centralize Jackson configuration used by `jsonShots()` and `processEnemyFire()` | JSON serialization currently recreates and configures `ObjectMapper` instances repeatedly | `#20` | Done on `Refactoring_110894` |
-| R4 | Vasco | `Tasks` | Break `menu()` into command handlers | The command loop concentrates many responsibilities and is the most complex CLI method in the project | - | Pending |
+| R4 | Vasco | `Tasks` | Break `menu()` into command handlers | The command loop concentrates many responsibilities and is the most complex CLI method in the project | `#39` | Done on `Refactoring_111331` |
 | R5 | Eduardo | `Game` | Extract summary-building helpers from `createSummary()` and `buildMoveSummary()` | Summary generation is correct but dense, which makes future changes harder to isolate | - | Done on `Refactoring_110894` |
 | R6 | Eduardo | `PdfExporter` | Consolidate repetitive PDF line-writing steps into small section helpers | The exporter is stable but still writes every section procedurally in a single method | - | Done on `Refactoring_110894` |
 | R7 | Tiago | `Messages` / `AppLanguage` | Extract and centralize default-language resolution paths | Language fallback logic is simple but duplicated conceptually across localization entry points | - | Pending |
 | R8 | Tiago | `LanguageSupport` / `Main` | Isolate CLI language parsing from application startup | Entry-point concerns and language resolution can be made more explicit and easier to test | - | Pending |
-| R9 | Vasco | `Tasks` | Extract history-printing and fleet-loading helpers from the CLI loop | `menu()` still mixes input orchestration with printing and persistence concerns | - | Pending |
+| R9 | Vasco | `Tasks` | Extract history-printing and fleet-loading helpers from the CLI loop | `menu()` still mixes input orchestration with printing and persistence concerns | `#39` | Done on `Refactoring_111331` |
 | R10 | Eduardo | `Move` | Split verbose text construction from JSON response construction | `processEnemyFire()` currently handles counting, message construction and serialization in one method | - | Done on `Refactoring_110894` |
 
 ## Execution rules

--- a/src/main/java/battleship/GameHistory.java
+++ b/src/main/java/battleship/GameHistory.java
@@ -1,66 +1,87 @@
 package battleship;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
 public class GameHistory {
 
+    private static final Logger LOGGER = LogManager.getLogger(GameHistory.class);
     private static final String DB_URL = "jdbc:h2:./battleship_history";
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS game_summary (" +
+            "id INT AUTO_INCREMENT PRIMARY KEY," +
+            "finished_at TIMESTAMP," +
+            "total_moves INT," +
+            "hits INT," +
+            "sunk_ships INT," +
+            "remaining_ships INT," +
+            "result VARCHAR(255)" +
+            ")";
+    private static final String INSERT_GAME_SQL =
+            "INSERT INTO game_summary (finished_at, total_moves, hits, sunk_ships, remaining_ships, result) VALUES (?, ?, ?, ?, ?, ?)";
+    private static final String SELECT_HISTORY_SQL = "SELECT * FROM game_summary ORDER BY finished_at DESC";
 
     public GameHistory() {
-        try (Connection conn = DriverManager.getConnection(DB_URL);
+        try (Connection conn = openConnection();
              Statement stmt = conn.createStatement()) {
-            String sql = "CREATE TABLE IF NOT EXISTS game_summary (" +
-                    "id INT AUTO_INCREMENT PRIMARY KEY," +
-                    "finished_at TIMESTAMP," +
-                    "total_moves INT," +
-                    "hits INT," +
-                    "sunk_ships INT," +
-                    "remaining_ships INT," +
-                    "result VARCHAR(255)" +
-                    ")";
-            stmt.executeUpdate(sql);
+            stmt.executeUpdate(CREATE_TABLE_SQL);
         } catch (SQLException e) {
-            e.printStackTrace();
+            logDatabaseError("Unable to initialize game history database.", e);
         }
     }
 
     public void saveGame(Timestamp finishedAt, int totalMoves, int hits, int sunkShips, int remainingShips, String result) {
-        String sql = "INSERT INTO game_summary (finished_at, total_moves, hits, sunk_ships, remaining_ships, result) VALUES (?, ?, ?, ?, ?, ?)";
-        try (Connection conn = DriverManager.getConnection(DB_URL);
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
-            pstmt.setTimestamp(1, finishedAt);
-            pstmt.setInt(2, totalMoves);
-            pstmt.setInt(3, hits);
-            pstmt.setInt(4, sunkShips);
-            pstmt.setInt(5, remainingShips);
-            pstmt.setString(6, result);
+        try (Connection conn = openConnection();
+             PreparedStatement pstmt = conn.prepareStatement(INSERT_GAME_SQL)) {
+            bindGameSummary(pstmt, finishedAt, totalMoves, hits, sunkShips, remainingShips, result);
             pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            logDatabaseError("Unable to save game history entry.", e);
         }
     }
 
     public List<String> getHistory() {
         List<String> history = new ArrayList<>();
-        String sql = "SELECT * FROM game_summary ORDER BY finished_at DESC";
-        try (Connection conn = DriverManager.getConnection(DB_URL);
+        try (Connection conn = openConnection();
              Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
+             ResultSet rs = stmt.executeQuery(SELECT_HISTORY_SQL)) {
             while (rs.next()) {
-                String entry = String.format("Game finished at: %s, Moves: %d, Hits: %d, Sunk Ships: %d, Remaining Ships: %d, Result: %s",
-                        rs.getTimestamp("finished_at"),
-                        rs.getInt("total_moves"),
-                        rs.getInt("hits"),
-                        rs.getInt("sunk_ships"),
-                        rs.getInt("remaining_ships"),
-                        rs.getString("result"));
-                history.add(entry);
+                history.add(formatHistoryEntry(rs));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logDatabaseError("Unable to read game history.", e);
         }
         return history;
+    }
+
+    private static Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(DB_URL);
+    }
+
+    private static void bindGameSummary(PreparedStatement pstmt, Timestamp finishedAt, int totalMoves, int hits,
+                                        int sunkShips, int remainingShips, String result) throws SQLException {
+        pstmt.setTimestamp(1, finishedAt);
+        pstmt.setInt(2, totalMoves);
+        pstmt.setInt(3, hits);
+        pstmt.setInt(4, sunkShips);
+        pstmt.setInt(5, remainingShips);
+        pstmt.setString(6, result);
+    }
+
+    private static String formatHistoryEntry(ResultSet rs) throws SQLException {
+        return String.format("Game finished at: %s, Moves: %d, Hits: %d, Sunk Ships: %d, Remaining Ships: %d, Result: %s",
+                rs.getTimestamp("finished_at"),
+                rs.getInt("total_moves"),
+                rs.getInt("hits"),
+                rs.getInt("sunk_ships"),
+                rs.getInt("remaining_ships"),
+                rs.getString("result"));
+    }
+
+    private static void logDatabaseError(String message, SQLException exception) {
+        LOGGER.error(message, exception);
     }
 }

--- a/src/main/java/battleship/Tasks.java
+++ b/src/main/java/battleship/Tasks.java
@@ -29,88 +29,32 @@ public class Tasks {
 	private static final String STATUS = "estado";
 	private static final String SIMULA = "simula";
 	private static final String HISTORICO = "historico";
+	private static final String HISTORY_HEADER = "======================= HISTORICO DE JOGOS =======================";
+	private static final String HISTORY_FOOTER = "===============================================================";
+	private static final String[][] HELP_LINES = {
+			{GERAFROTA, "menu.description.gerafrota"},
+			{LEFROTA, "menu.description.lefrota"},
+			{STATUS, "menu.description.estado"},
+			{MAPA, "menu.description.mapa"},
+			{RAJADA, "menu.description.rajada"},
+			{SIMULA, "menu.description.simula"},
+			{TIROS, "menu.description.tiros"},
+			{HISTORICO, "menu.description.historico"},
+			{DESISTIR, "menu.description.desisto"}
+	};
 
 	/**
 	 * This task also tests the fighting element of a round of three shots.
 	 */
 	public static void menu() {
-		IFleet myFleet = null;
-		IGame game = null;
+		MenuState state = new MenuState();
 		menuHelp();
 
 		System.out.print("> ");
 		Scanner in = new Scanner(System.in);
 		String command = in.next();
 		while (!command.equals(DESISTIR)) {
-			switch (command) {
-				case GERAFROTA:
-					myFleet = Fleet.createRandom();
-					game = new Game(myFleet);
-					game.printMyBoard(false, true);
-					break;
-				case LEFROTA:
-					myFleet = buildFleet(in);
-					game = new Game(myFleet);
-					game.printMyBoard(false, true);
-					break;
-				case STATUS:
-					if (myFleet != null)
-						myFleet.printStatus();
-					break;
-				case MAPA:
-					if (myFleet != null)
-						game.printMyBoard(false, true);
-					break;
-				case RAJADA:
-					if (game != null) {
-						game.readEnemyFire(in);
-						myFleet.printStatus();
-						game.printMyBoard(true, false);
-
-						if (game.getRemainingShips() == 0) {
-							game.over();
-							System.exit(0);
-						}
-					}
-					break;
-				case SIMULA:
-					if (game != null) {
-						while (game.getRemainingShips() > 0) {
-							game.randomEnemyFire();
-							myFleet.printStatus();
-							game.printMyBoard(true, false);
-							try {
-								Thread.sleep(3000);
-							} catch (InterruptedException e) {
-								Thread.currentThread().interrupt();
-							}
-						}
-
-						if (game.getRemainingShips() == 0) {
-							game.over();
-							System.exit(0);
-						}
-					}
-					break;
-				case TIROS:
-					if (game != null)
-						game.printMyBoard(true, true);
-					break;
-				case HISTORICO:
-					GameHistory gameHistory = new GameHistory();
-					List<String> history = gameHistory.getHistory();
-					System.out.println("======================= HISTORICO DE JOGOS =======================");
-					for (String entry : history) {
-						System.out.println(entry);
-					}
-					System.out.println("===============================================================");
-					break;
-				case AJUDA:
-					menuHelp();
-					break;
-				default:
-					System.out.println(Messages.get("menu.unknown"));
-			}
+			handleCommand(command, in, state);
 			System.out.print("> ");
 			command = in.next();
 		}
@@ -123,15 +67,9 @@ public class Tasks {
 	public static void menuHelp() {
 		System.out.println(Messages.get("menu.help.header"));
 		System.out.println(Messages.get("menu.help.instructions"));
-		printHelpLine(GERAFROTA, "menu.description.gerafrota");
-		printHelpLine(LEFROTA, "menu.description.lefrota");
-		printHelpLine(STATUS, "menu.description.estado");
-		printHelpLine(MAPA, "menu.description.mapa");
-		printHelpLine(RAJADA, "menu.description.rajada");
-		printHelpLine(SIMULA, "menu.description.simula");
-		printHelpLine(TIROS, "menu.description.tiros");
-		printHelpLine(HISTORICO, "menu.description.historico");
-		printHelpLine(DESISTIR, "menu.description.desisto");
+		for (String[] helpLine : HELP_LINES) {
+			printHelpLine(helpLine[0], helpLine[1]);
+		}
 		System.out.println(Messages.get("menu.help.footer"));
 	}
 
@@ -149,20 +87,14 @@ public class Tasks {
 		assert in != null;
 
 		Fleet fleet = new Fleet();
-		int i = 0;
-		while (i < Fleet.FLEET_SIZE) {
-			IShip s = readShip(in);
-			if (s != null) {
-				boolean success = fleet.addShip(s);
-				if (success)
-					i++;
-				else
-					LOGGER.info("Falha na criacao de {} {} {}", s.getCategory(), s.getBearing(), s.getPosition());
-			} else {
-				LOGGER.info("Navio desconhecido!");
+		int addedShips = 0;
+		while (addedShips < Fleet.FLEET_SIZE) {
+			IShip ship = readShip(in);
+			if (addShipIfPossible(fleet, ship)) {
+				addedShips++;
 			}
 		}
-		LOGGER.info("{} navios adicionados com sucesso!", i);
+		LOGGER.info("{} navios adicionados com sucesso!", addedShips);
 		return fleet;
 	}
 
@@ -229,5 +161,126 @@ public class Tasks {
 		}
 
 		throw new IllegalArgumentException(Messages.get("position.invalid"));
+	}
+
+	private static void handleCommand(String command, Scanner in, MenuState state) {
+		switch (command) {
+			case GERAFROTA:
+				loadFleet(Fleet.createRandom(), state);
+				break;
+			case LEFROTA:
+				loadFleet(buildFleet(in), state);
+				break;
+			case STATUS:
+				printFleetStatus(state);
+				break;
+			case MAPA:
+				printFleetMap(state);
+				break;
+			case RAJADA:
+				processBurst(in, state);
+				break;
+			case SIMULA:
+				simulateGame(state);
+				break;
+			case TIROS:
+				printShots(state);
+				break;
+			case HISTORICO:
+				printHistory(new GameHistory());
+				break;
+			case AJUDA:
+				menuHelp();
+				break;
+			default:
+				System.out.println(Messages.get("menu.unknown"));
+		}
+	}
+
+	private static void loadFleet(IFleet fleet, MenuState state) {
+		state.myFleet = fleet;
+		state.game = new Game(fleet);
+		state.game.printMyBoard(false, true);
+	}
+
+	private static void printFleetStatus(MenuState state) {
+		if (state.myFleet != null) {
+			state.myFleet.printStatus();
+		}
+	}
+
+	private static void printFleetMap(MenuState state) {
+		if (state.game != null) {
+			state.game.printMyBoard(false, true);
+		}
+	}
+
+	private static void processBurst(Scanner in, MenuState state) {
+		if (state.game != null) {
+			state.game.readEnemyFire(in);
+			state.myFleet.printStatus();
+			state.game.printMyBoard(true, false);
+			exitIfGameOver(state.game);
+		}
+	}
+
+	private static void simulateGame(MenuState state) {
+		if (state.game != null) {
+			while (state.game.getRemainingShips() > 0) {
+				state.game.randomEnemyFire();
+				state.myFleet.printStatus();
+				state.game.printMyBoard(true, false);
+				pauseSimulation();
+			}
+			exitIfGameOver(state.game);
+		}
+	}
+
+	private static void printShots(MenuState state) {
+		if (state.game != null) {
+			state.game.printMyBoard(true, true);
+		}
+	}
+
+	private static void printHistory(GameHistory gameHistory) {
+		List<String> history = gameHistory.getHistory();
+		System.out.println(HISTORY_HEADER);
+		for (String entry : history) {
+			System.out.println(entry);
+		}
+		System.out.println(HISTORY_FOOTER);
+	}
+
+	private static boolean addShipIfPossible(Fleet fleet, IShip ship) {
+		if (ship == null) {
+			LOGGER.info("Navio desconhecido!");
+			return false;
+		}
+
+		boolean success = fleet.addShip(ship);
+		if (!success) {
+			LOGGER.info("Falha na criacao de {} {} {}", ship.getCategory(), ship.getBearing(), ship.getPosition());
+		}
+		return success;
+	}
+
+	private static void pauseSimulation() {
+		try {
+			Thread.sleep(3000);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private static void exitIfGameOver(IGame game) {
+		if (game.getRemainingShips() == 0) {
+			game.over();
+			System.exit(0);
+		}
+	}
+
+	private static final class MenuState {
+		private IFleet myFleet;
+		private IGame game;
 	}
 }

--- a/src/test/java/battleship/GameHistoryTest.java
+++ b/src/test/java/battleship/GameHistoryTest.java
@@ -1,19 +1,27 @@
 package battleship;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -35,20 +43,19 @@ class GameHistoryTest {
 	private static final String DB_FILE = "./battleship_history.mv.db";
 	private static final String DB_TRACE_FILE = "./battleship_history.trace.db";
 	private static final String DB_URL = "jdbc:h2:./battleship_history";
+	private static final String LOGGER_NAME = GameHistory.class.getName();
 
-	private final PrintStream originalErr = System.err;
-	private ByteArrayOutputStream errContent;
+	private TestLogAppender logAppender;
 
 	@BeforeEach
 	void setUp() {
-		errContent = new ByteArrayOutputStream();
-		System.setErr(new PrintStream(errContent, true, StandardCharsets.UTF_8));
+		logAppender = attachLogAppender();
 		cleanup();
 	}
 
 	@AfterEach
 	void tearDown() {
-		System.setErr(originalErr);
+		detachLogAppender(logAppender);
 		cleanup();
 	}
 
@@ -149,20 +156,20 @@ class GameHistoryTest {
 	}
 
 	@Test
-	@DisplayName("saveGame prints the SQL error when the backing table is missing")
-	void saveGamePrintsSQLExceptionWhenTableIsMissing() throws Exception {
+	@DisplayName("saveGame logs the SQL error when the backing table is missing")
+	void saveGameLogsSQLExceptionWhenTableIsMissing() throws Exception {
 		GameHistory gameHistory = new GameHistory();
 		dropHistoryTable();
 
 		gameHistory.saveGame(Timestamp.valueOf("2026-05-06 15:00:00"), 1, 1, 1, 10, "WIN");
 
-		assertTrue(stderr().contains("JdbcSQLSyntaxErrorException"),
-				"Error: expected saveGame() to print the observable SQL exception to stderr.");
+		assertLoggedError("Unable to save game history entry.",
+				"Error: expected saveGame() to log the observable SQL failure.");
 	}
 
 	@Test
-	@DisplayName("getHistory returns an empty list and prints the SQL error when the table is missing")
-	void getHistoryReturnsEmptyAndPrintsSQLExceptionWhenTableIsMissing() throws Exception {
+	@DisplayName("getHistory returns an empty list and logs the SQL error when the table is missing")
+	void getHistoryReturnsEmptyAndLogsSQLExceptionWhenTableIsMissing() throws Exception {
 		GameHistory gameHistory = new GameHistory();
 		dropHistoryTable();
 
@@ -171,8 +178,8 @@ class GameHistoryTest {
 		assertAll(
 				() -> assertTrue(history.isEmpty(),
 						"Error: expected getHistory() to return an empty list after a SQL failure."),
-				() -> assertTrue(stderr().contains("JdbcSQLSyntaxErrorException"),
-						"Error: expected getHistory() to print the observable SQL exception to stderr.")
+				() -> assertLoggedError("Unable to read game history.",
+						"Error: expected getHistory() to log the observable SQL failure.")
 		);
 	}
 
@@ -183,8 +190,12 @@ class GameHistoryTest {
 		}
 	}
 
-	private String stderr() {
-		return errContent.toString(StandardCharsets.UTF_8);
+	private void assertLoggedError(String expectedMessage, String assertionMessage) {
+		boolean found = logAppender.events().stream()
+				.anyMatch(event -> event.getLevel().equals(Level.ERROR)
+						&& event.getMessage().getFormattedMessage().equals(expectedMessage)
+						&& event.getThrown() instanceof SQLException);
+		assertTrue(found, assertionMessage);
 	}
 
 	private void cleanup() {
@@ -197,5 +208,43 @@ class GameHistoryTest {
 
 		new File(DB_FILE).delete();
 		new File(DB_TRACE_FILE).delete();
+	}
+
+	private TestLogAppender attachLogAppender() {
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		Configuration configuration = context.getConfiguration();
+		TestLogAppender appender = new TestLogAppender("GameHistoryTestAppender");
+		appender.start();
+		configuration.addAppender(appender);
+		LoggerConfig loggerConfig = new LoggerConfig(LOGGER_NAME, Level.ERROR, false);
+		loggerConfig.addAppender(appender, Level.ERROR, null);
+		configuration.addLogger(LOGGER_NAME, loggerConfig);
+		context.updateLoggers();
+		return appender;
+	}
+
+	private void detachLogAppender(Appender appender) {
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		Configuration configuration = context.getConfiguration();
+		configuration.removeLogger(LOGGER_NAME);
+		appender.stop();
+		context.updateLoggers();
+	}
+
+	private static final class TestLogAppender extends AbstractAppender {
+		private final List<LogEvent> events = new ArrayList<>();
+
+		private TestLogAppender(String name) {
+			super(name, (Filter) null, PatternLayout.createDefaultLayout(), false, null);
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		private List<LogEvent> events() {
+			return events;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces duplicated `GameHistory` stack trace handling with Log4j error reporting and shared SQL helpers.
- Splits `Tasks.menu()` into command handlers and a small menu state holder.
- Extracts history printing, fleet loading, simulation pause and game-over helpers.
- Marks Vasco's R1/R4/R9 backlog entries as complete with linked issues.

## Validation
- `mvn test`: 216 tests, 0 failures, 0 errors.
- `mvn clean verify javadoc:javadoc`: build success; existing Javadoc/shade warnings only.

Closes #23
Closes #39