### PR TITLE
Implement Ficha 6 base container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Dockerfile
+!.dockerignore
+!target/
+target/*
+!target/BattleshipGamePlayer-2.0.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+LABEL org.opencontainers.image.title="Battleship2"
+LABEL org.opencontainers.image.description="Container image for the Battleship2 Java CLI application"
+LABEL org.opencontainers.image.source="https://github.com/rtz15/Battleship2"
+
+WORKDIR /app
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin battleship \
+    && mkdir -p /app/output \
+    && chown -R battleship:battleship /app
+
+COPY target/BattleshipGamePlayer-2.0.jar /app/battleship-game.jar
+
+USER battleship
+
+ENTRYPOINT ["java", "-jar", "/app/battleship-game.jar"]


### PR DESCRIPTION
## Summary
- add a production-oriented `Dockerfile` for the Battleship2 Java CLI application
- add a narrow `.dockerignore` that keeps the Docker build context focused on the packaged shaded jar
- run the container image with Java 21 on a non-root user and preserve the expected `/app/output` runtime directory
- keep Docker Hub publication workflow and project-level `docker-compose.yml` work out of this PR because those slices are owned by other branches in the team plan

## Validation
- `mvn clean package`
- `docker build -t battleship-game:latest .`
- `cmd /c "echo desisto| docker run -i --rm battleship-game:latest"`
- `cmd /c "echo desisto| docker run -i --rm battleship-game:latest --lang en"`

Closes #48