### PR TITLE
docs(ficha5): add YouTube demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Battleship2 is a Java 21 command-line implementation of Battleship developed for the Software Engineering coursework. The current `main` branch already includes the Ficha 2 gameplay extensions, the Ficha 3 quality-analysis artifacts, and the Ficha 4 JUnit 6 testing phase.
 
 > Ficha 2 demo video: [Watch on YouTube](https://youtu.be/S00AQphHRkE)
+>
+> Ficha 5 acceptance tests demo video: [Watch on YouTube](https://youtu.be/srEkP3WnjWI)
 
 ## Team
 - `110894` Eduardo Sousa


### PR DESCRIPTION
Esta atualizacao ao `README.md` foi separada para manter o trabalho tecnico da Ficha 5 e da Ficha 6 fora desta correcao documental.

O link publico da demonstracao da Ficha 5 devia estar no topo do README, como pedido no enunciado, mas nao tinha sido acrescentado anteriormente.

Alteracao incluida:
- adicao do link do video de demonstracao da Ficha 5 no topo do `README.md`

Link adicionado:
- `https://youtu.be/srEkP3WnjWI`

Validacao:
- confirmada a presenca do link no topo do `README.md` na branch `docs/ficha5-youtube-link`