### PR TITLE
Implement Ficha 6 Docker packaging and publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Dockerfile
+!.dockerignore
+!target/
+target/*
+!target/BattleshipGamePlayer-2.0.jar

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,58 @@
+name: Docker Publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  configuration-check:
+    if: ${{ env.DOCKERHUB_USERNAME == '' || env.DOCKERHUB_TOKEN == '' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip publish because Docker Hub credentials are missing
+        run: echo "Skipping Docker publish. Configure DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to enable this workflow."
+
+  publish:
+    if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Build shaded jar
+        run: mvn -B clean package --file pom.xml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Build and publish Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKERHUB_USERNAME }}/battleship-game:latest
+            ${{ env.DOCKERHUB_USERNAME }}/battleship-game:${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,16 +40,16 @@ jobs:
         run: mvn -B clean package --file pom.xml
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Build and publish Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jre
+
+LABEL org.opencontainers.image.title="Battleship2"
+LABEL org.opencontainers.image.description="Container image for the Battleship2 Java CLI application"
+LABEL org.opencontainers.image.source="https://github.com/rtz15/Battleship2"
+
+WORKDIR /app
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin battleship \
+    && mkdir -p /app/output \
+    && chown -R battleship:battleship /app
+
+COPY target/BattleshipGamePlayer-2.0.jar /app/battleship-game.jar
+
+USER battleship
+
+ENTRYPOINT ["java", "-jar", "/app/battleship-game.jar"]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,45 @@ mvn -Pacceptance-tests clean test
 The current versioned Ficha 5 acceptance report is:
 - `reports/ficha5-acceptance-tests-allure-20260514-132642`
 
+## Ficha 6 distribution and operation
+
+The Ficha 6 deliverable packages the Battleship CLI as a Docker image and automates publication through GitHub Actions.
+
+### Local Docker image
+
+Build the shaded application jar:
+
+```bash
+mvn clean package
+```
+
+Build the local Docker image requested in the assignment:
+
+```bash
+docker build -t battleship-game:latest .
+```
+
+Run the container interactively:
+
+```bash
+docker run --rm -it battleship-game:latest
+```
+
+The repository includes:
+- `Dockerfile` based on `eclipse-temurin:21-jre`
+- `.dockerignore` tuned to ship only the shaded jar to the Docker build context
+- `.github/workflows/docker-publish.yml` to build and publish `${DOCKERHUB_USERNAME}/battleship-game`
+
+### Docker Hub publication workflow
+
+The Docker publication workflow runs on pushes to `main` and on manual dispatch. Before using it, configure the repository with:
+- repository variable `DOCKERHUB_USERNAME`
+- repository secret `DOCKERHUB_TOKEN`
+
+Once those credentials exist, the workflow publishes:
+- `${DOCKERHUB_USERNAME}/battleship-game:latest`
+- `${DOCKERHUB_USERNAME}/battleship-game:${GITHUB_SHA}`
+
 ## Project artifacts
 
 - Code metrics: [CodeMetrics/README.md](CodeMetrics/README.md)


### PR DESCRIPTION
Closes #51 

## Summary
- add a Dockerfile for the Battleship CLI application
- add a .dockerignore focused on the shaded jar build context
- add a GitHub Actions workflow to build and publish the Docker image to Docker Hub
- document Ficha 6 Docker build and publication steps in the README

## Validation
- `mvn clean package`
- `docker build -t battleship-game:latest .`
- `printf 'gerafrota\nestado\nmapa\nhistorico\ndesisto\n' | docker run --rm -i battleship-game:latest`
- `docker run --platform linux/amd64 --name ficha6-xampp -p 41061:22 -p 41062:80 -d tomsik68/xampp`
- `curl http://localhost:41062/www/` after copying `index.php` into `/www/`
- `docker run --name ficha6-mongodb -p 27017:27017 -d mongo:latest`
- `docker exec ficha6-mongodb mongosh --quiet --eval ...` to insert and query sample records


## Notes
- `tomsik68/xampp` was validated on Apple Silicon using `--platform linux/amd64`
- configure `DOCKERHUB_USERNAME` as a repository variable
- configure `DOCKERHUB_TOKEN` as a repository secret